### PR TITLE
Fix code scanning alerts 1-5: workflows do not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: publish
+permissions:
+  contents: read
 on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   release:
@@ -93,6 +95,8 @@ jobs:
         run: dotnet test -c Release
 
   deploy:
+    permissions:
+      contents: write
     # Publish only when creating a GitHub Release
     # https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
     # You can update this logic if you want to manage releases differently


### PR DESCRIPTION
Fix for all 5 code scanning alerts of rule `actions/missing-workflow-permissions` ("Workflow does not contain permissions"), one per workflow job:

| Alert | Job |
| --- | --- |
| [1](https://github.com/pabloFuente/livekit-server-sdk-dotnet/security/code-scanning/1) | `build` in `.github/workflows/dotnet.yml` |
| [2](https://github.com/pabloFuente/livekit-server-sdk-dotnet/security/code-scanning/2) | `create_nuget` in `.github/workflows/publish.yml` |
| [3](https://github.com/pabloFuente/livekit-server-sdk-dotnet/security/code-scanning/3) | `validate_nuget` in `.github/workflows/publish.yml` |
| [4](https://github.com/pabloFuente/livekit-server-sdk-dotnet/security/code-scanning/4) | `run_test` in `.github/workflows/publish.yml` |
| [5](https://github.com/pabloFuente/livekit-server-sdk-dotnet/security/code-scanning/5) | `deploy` in `.github/workflows/publish.yml` |

Changes:

1. `.github/workflows/publish.yml`: workflow-level `permissions: contents: read`, so every job gets minimal access by default.
2. `.github/workflows/publish.yml`: job-level override on `deploy` with `contents: write`, because `stefanzweifel/git-auto-commit-action` pushes the post-release commit.
3. `.github/workflows/dotnet.yml`: workflow-level `permissions: contents: read`. Its only job checks out, restores, builds, tests and packs, so read access is enough.

All existing behavior is unchanged (same triggers, jobs, steps), only token scope changes.

_Alert 5 fix originally suggested by Copilot Autofix; extended to cover the remaining alerts._
